### PR TITLE
hotfix proposal for loading issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export class CalingaBackend implements BackendModule<CalingaBackendOptions> {
         this.options = { ...this.getDefaultOptions(), ...backendOptions };
 
         if (backendOptions) {
-            options.ns = [backendOptions.project];
+            options.ns = options.ns || [backendOptions.project];
             options.defaultNS = backendOptions.project;
         }
 


### PR DESCRIPTION
The settings in initial configuration are overwritten in the init function and as a result, only one namespace is loaded initially and in some cases the remaining namespaces are not loaded or create a infinite loop.